### PR TITLE
Joints to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Pycharm project settings
+.idea/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@ Authors
 * Philippe Fleischmann <fleischmann@arch.ethz.ch> `@fleischp <https://github.com/fleischp>`_
 * Gonzalo Casas <casas@arch.ethz.ch> `@gonzalocasas <https://github.com/gonzalocasas>`_
 * Michael Lyrenmann <lyrenmann@arch.ethz.ch>
+* Beverly Lytle <lytle@arch.ethz.ch> `@beverlylytle <https://github.com/beverlylytle>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Unreleased
 
 **Added**
 
-* Added `to_configuration` and `to_configuration_primtiive` to `compas_rrc.ExternalAxes` and `compas_rrc.RobotJoints`
+* Added `to_configuration` and `to_configuration_primitive` to `compas_rrc.ExternalAxes` and `compas_rrc.RobotJoints`
 
 **Changed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Unreleased
 
 **Added**
 
+* Added `to_configuration` to `compas_rrc.ExternalAxes` and `compas_rrc.RobotJoints`
+
 **Changed**
 
 **Fixed**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Unreleased
 
 **Added**
 
-* Added `to_configuration` to `compas_rrc.ExternalAxes` and `compas_rrc.RobotJoints`
+* Added `to_configuration` and `to_configuration_primtiive` to `compas_rrc.ExternalAxes` and `compas_rrc.RobotJoints`
 
 **Changed**
 

--- a/src/compas_rrc/common.py
+++ b/src/compas_rrc/common.py
@@ -188,8 +188,8 @@ class ExternalAxes(object):
     def __iter__(self):
         return iter(self.values)
 
-    # Convenience methods
-    def to_configuration(self, joint_types, joint_names=None):
+    # Conversion methods
+    def to_configuration_primitive(self, joint_types, joint_names=None):
         """Convert the ExternalAxes to a :class:`compas.robots.Configuration`.
 
         Parameters
@@ -206,8 +206,27 @@ class ExternalAxes(object):
         joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
         return Configuration(joint_values, joint_types, joint_names)
 
+    def to_configuration(self, robot, group=None):
+        """Convert the ExternalAxes to a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        robot : :class:`compas_fab.robots.Robot`
+            The robot to be configured.
+        group : :obj:`str`
+            The name of the group of joints to be included in the ``Configuration``. Optional.
+            Defaults to the ``robot``'s main group name.
+
+        Returns
+        -------
+        :class:`compas.robots.Configuration`
+        """
+        joint_types = robot.get_configurable_joint_types(group)
+        joint_names = robot.get_configurable_joint_names(group)
+        return self.to_configuration_primitive(joint_types, joint_names)
+
     @classmethod
-    def from_configuration(cls, configuration, joint_names=None):
+    def from_configuration_primitive(cls, configuration, joint_names=None):
         """Create an instance of ``ExternalAxes`` from a :class:`compas.robots.Configuration`.
 
         Parameters
@@ -225,6 +244,27 @@ class ExternalAxes(object):
         if joint_names:
             return cls(configuration[name] for name in joint_names)
         return cls(configuration.joint_values)
+
+    @classmethod
+    def from_configuration(cls, configuration, robot=None, group=None):
+        """Create an instance of ``ExternalAxes`` from a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        configuration : :class:`compas.robots.Configuration`
+            The configuration from which to create the ``ExternalAxes`` instance.
+        robot : :class:`compas_fab.robots.Robot`
+            The robot to be configured.  Optional.
+        group : :obj:`str`
+            The name of the group of joints to be included in the ``ExternalAxes``. Optional.
+            Defaults to the ``robot``'s main group name.
+
+        Returns
+        -------
+        :class:`compas_rrc.ExternalAxes`
+        """
+        joint_names = robot.get_configurable_joint_names(group) if robot else []
+        return cls.from_configuration_primitive(configuration, joint_names)
 
 
 class RobotJoints(object):
@@ -304,8 +344,8 @@ class RobotJoints(object):
     def __iter__(self):
         return iter(self.values)
 
-    # Convenience methods
-    def to_configuration(self, joint_types, joint_names=None):
+    # Conversion methods
+    def to_configuration_primitive(self, joint_types, joint_names=None):
         """Convert the RobotJoints to a :class:`compas.robots.Configuration`.
 
         Parameters
@@ -322,8 +362,27 @@ class RobotJoints(object):
         joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
         return Configuration(joint_values, joint_types, joint_names)
 
+    def to_configuration(self, robot, group=None):
+        """Convert the RobotJoints to a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        robot : :class:`compas_fab.robots.Robot`
+            The robot to be configured.
+        group : :obj:`str`
+            The name of the group of joints to be included in the ``Configuration``. Optional.
+            Defaults to the ``robot``'s main group name.
+
+        Returns
+        -------
+        :class:`compas.robots.Configuration`
+        """
+        joint_types = robot.get_configurable_joint_types(group)
+        joint_names = robot.get_configurable_joint_names(group)
+        return self.to_configuration_primitive(joint_types, joint_names)
+
     @classmethod
-    def from_configuration(cls, configuration, joint_names=None):
+    def from_configuration_primitive(cls, configuration, joint_names=None):
         """Create an instance of ``RobotJoints`` from a :class:`compas.robots.Configuration`.
 
         Parameters
@@ -341,3 +400,24 @@ class RobotJoints(object):
         if joint_names:
             return cls(configuration[name] for name in joint_names)
         return cls(configuration.joint_values)
+
+    @classmethod
+    def from_configuration(cls, configuration, robot=None, group=None):
+        """Create an instance of ``RobotJoints`` from a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        configuration : :class:`compas.robots.Configuration`
+            The configuration from which to create the ``ExternalAxes`` instance.
+        robot : :class:`compas_fab.robots.Robot`
+            The robot to be configured.  Optional.
+        group : :obj:`str`
+            The name of the group of joints to be included in the ``ExternalAxes``. Optional.
+            Defaults to the ``robot``'s main group name.
+
+        Returns
+        -------
+        :class:`compas_rrc.RobotJoints`
+        """
+        joint_names = robot.get_configurable_joint_names(group) if robot else []
+        return cls.from_configuration_primitive(configuration, joint_names)

--- a/src/compas_rrc/common.py
+++ b/src/compas_rrc/common.py
@@ -194,18 +194,37 @@ class ExternalAxes(object):
 
         Parameters
         ----------
-        joint_types : obj:`list`
+        joint_types : :obj:`list`
             List of integers representing the joint types of the corresponding external axes values.
-        joint_names : obj:`list`
+        joint_names : :obj:`list`
             List of strings representing the joint names of the corresponding external axes values. Optional.
 
         Returns
         -------
         :class:`compas.robots.Configuration`
-
         """
         joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
         return Configuration(joint_values, joint_types, joint_names)
+
+    @classmethod
+    def from_configuration(cls, configuration, joint_names=None):
+        """Create an instance of ``ExternalAxes`` from a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        configuration : :class:`compas.robots.Configuration`
+            The configuration from which to create the ``ExternalAxes`` instance.
+        joint_names : :obj:`list`
+            An optional list of joint names from the ``configuration`` whose corresponding
+            values will fill the ``ExternalAxes`` values.
+
+        Returns
+        -------
+        :class:`compas_rrc.ExternalAxes`
+        """
+        if joint_names:
+            return cls(configuration[name] for name in joint_names)
+        return cls(configuration.joint_values)
 
 
 class RobotJoints(object):
@@ -291,15 +310,34 @@ class RobotJoints(object):
 
         Parameters
         ----------
-        joint_types : obj:`list`
+        joint_types : :obj:`list`
             List of integers representing the joint types of the corresponding internal axes values.
-        joint_names : obj:`list`
+        joint_names : :obj:`list`
             List of strings representing the joint names of the corresponding internal axes values. Optional.
 
         Returns
         -------
         :class:`compas.robots.Configuration`
-
         """
         joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
         return Configuration(joint_values, joint_types, joint_names)
+
+    @classmethod
+    def from_configuration(cls, configuration, joint_names=None):
+        """Create an instance of ``RobotJoints`` from a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        configuration : :class:`compas.robots.Configuration`
+            The configuration from which to create the ``RobotJoints`` instance.
+        joint_names : :obj:`list`
+            An optional list of joint names from the ``configuration`` whose corresponding
+            values will fill the ``RobotJoints`` values.
+
+        Returns
+        -------
+        :class:`compas_rrc.RobotJoints`
+        """
+        if joint_names:
+            return cls(configuration[name] for name in joint_names)
+        return cls(configuration.joint_values)

--- a/src/compas_rrc/common.py
+++ b/src/compas_rrc/common.py
@@ -1,5 +1,9 @@
 import itertools
+import math
 import threading
+
+from compas.robots import Configuration
+from compas.robots import Joint
 
 __all__ = ['CLIENT_PROTOCOL_VERSION',
            'FeedbackLevel',
@@ -10,8 +14,13 @@ __all__ = ['CLIENT_PROTOCOL_VERSION',
            'ExternalAxes',
            'RobotJoints']
 
-
 CLIENT_PROTOCOL_VERSION = 2
+
+
+def _convert_unit(value, type_):
+    if type_ in {Joint.REVOLUTE, Joint.CONTINUOUS}:
+        return math.radians(value)
+    return value / 1000
 
 
 class FeedbackLevel(object):
@@ -179,6 +188,25 @@ class ExternalAxes(object):
     def __iter__(self):
         return iter(self.values)
 
+    # Convenience methods
+    def to_configuration(self, joint_types, joint_names=None):
+        """Convert the ExternalAxes to a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        joint_types : obj:`list`
+            List of integers representing the joint types of the corresponding external axes values.
+        joint_names : obj:`list`
+            List of strings representing the joint names of the corresponding external axes values. Optional.
+
+        Returns
+        -------
+        :class:`compas.robots.Configuration`
+
+        """
+        joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
+        return Configuration(joint_values, joint_types, joint_names)
+
 
 class RobotJoints(object):
     """Represents a configuration for robot joints"""
@@ -256,3 +284,22 @@ class RobotJoints(object):
 
     def __iter__(self):
         return iter(self.values)
+
+    # Convenience methods
+    def to_configuration(self, joint_types, joint_names=None):
+        """Convert the RobotJoints to a :class:`compas.robots.Configuration`.
+
+        Parameters
+        ----------
+        joint_types : obj:`list`
+            List of integers representing the joint types of the corresponding internal axes values.
+        joint_names : obj:`list`
+            List of strings representing the joint names of the corresponding internal axes values. Optional.
+
+        Returns
+        -------
+        :class:`compas.robots.Configuration`
+
+        """
+        joint_values = [_convert_unit(value, type_) for value, type_ in zip(self.values, joint_types)]
+        return Configuration(joint_values, joint_types, joint_names)

--- a/src/compas_rrc/utility.py
+++ b/src/compas_rrc/utility.py
@@ -166,7 +166,7 @@ class GetJoints(ROSmsg):
         :class:`RobotJoints`, :class:`ExternalAxes`
             Current joints and external axes of the robot.
         """
-        # read robot jonts
+        # read robot joints
         robot_joints = [result['float_values'][i] for i in range(0, 6)]
 
         # read external axes

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,17 @@
+import math
+
 import compas_rrc as rrc
+
+
+def test__convert_units():
+    v = rrc.common._convert_unit(180, 0)
+    assert v == math.pi
+
+    v = rrc.common._convert_unit(-180, 1)
+    assert v == -math.pi
+
+    v = rrc.common._convert_unit(2545, 2)
+    assert v == 2.545
 
 
 def test_robot_joints():
@@ -17,6 +30,16 @@ def test_robot_joints():
     j = rrc.RobotJoints(iter([30, 10, 0]))
     assert list(j) == [30, 10, 0]
 
+    j = rrc.RobotJoints(30, 45, 0)
+    c = j.to_configuration([0, 1, 2], ['j1', 'j2', 'j3'])
+    assert c.joint_values == [math.pi/6, math.pi/4, 0.0]
+    assert c.joint_names == ['j1', 'j2', 'j3']
+
+    j = rrc.RobotJoints(30, -45, 100)
+    c = j.to_configuration([0, 1, 2])
+    assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
+    assert len(c.joint_names) == 0
+
 
 def test_external_axes():
     ea = rrc.ExternalAxes()
@@ -28,8 +51,18 @@ def test_external_axes():
     ea = rrc.ExternalAxes(30, 10, 0)
     assert list(ea) == [30, 10, 0]
 
-    ea = rrc.ExternalAxes([30, 10, 0])
-    assert list(ea) == [30, 10, 0]
+    # ea = rrc.ExternalAxes([30, 10, 0])
+    # assert list(ea) == [30, 10, 0]
+    #
+    # ea = rrc.ExternalAxes(iter([30, 10, 0]))
+    # assert list(ea) == [30, 10, 0]
 
-    ea = rrc.ExternalAxes(iter([30, 10, 0]))
-    assert list(ea) == [30, 10, 0]
+    j = rrc.ExternalAxes(30, 45, 0)
+    c = j.to_configuration([0, 1, 2], ['j1', 'j2', 'j3'])
+    assert c.joint_values == [math.pi/6, math.pi/4, 0.0]
+    assert c.joint_names == ['j1', 'j2', 'j3']
+
+    j = rrc.ExternalAxes(30, -45, 100)
+    c = j.to_configuration([0, 1, 2])
+    assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
+    assert len(c.joint_names) == 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -32,22 +32,22 @@ def test_robot_joints():
     assert list(j) == [30, 10, 0]
 
     j = rrc.RobotJoints(30, 45, 0)
-    c = j.to_configuration([0, 1, 2], ['j1', 'j2', 'j3'])
+    c = j.to_configuration_primitive([0, 1, 2], ['j1', 'j2', 'j3'])
     assert c.joint_values == [math.pi/6, math.pi/4, 0.0]
     assert c.joint_names == ['j1', 'j2', 'j3']
 
     j = rrc.RobotJoints(30, -45, 100)
-    c = j.to_configuration([0, 1, 2])
+    c = j.to_configuration_primitive([0, 1, 2])
     assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
     assert len(c.joint_names) == 0
 
     config = Configuration([0, 1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0])
-    rj = rrc.RobotJoints.from_configuration(config)
+    rj = rrc.RobotJoints.from_configuration_primitive(config)
     assert rj.rax_1 == 0
     assert rj.rax_6 == 5
 
     config = Configuration([0, 1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0, 0], ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
-    rj = rrc.RobotJoints.from_configuration(config, ['b', 'c', 'd', 'e', 'f', 'g'])
+    rj = rrc.RobotJoints.from_configuration_primitive(config, ['b', 'c', 'd', 'e', 'f', 'g'])
     assert rj.rax_1 == 1
     assert rj.rax_6 == 6
 
@@ -69,21 +69,21 @@ def test_external_axes():
     assert list(ea) == [30, 10, 0]
 
     j = rrc.ExternalAxes(30, 45, 0)
-    c = j.to_configuration([0, 1, 2], ['j1', 'j2', 'j3'])
+    c = j.to_configuration_primitive([0, 1, 2], ['j1', 'j2', 'j3'])
     assert c.joint_values == [math.pi/6, math.pi/4, 0.0]
     assert c.joint_names == ['j1', 'j2', 'j3']
 
     j = rrc.ExternalAxes(30, -45, 100)
-    c = j.to_configuration([0, 1, 2])
+    c = j.to_configuration_primitive([0, 1, 2])
     assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
     assert len(c.joint_names) == 0
 
     config = Configuration([0, 1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0])
-    rj = rrc.ExternalAxes.from_configuration(config)
+    rj = rrc.ExternalAxes.from_configuration_primitive(config)
     assert rj.eax_a == 0
     assert rj.eax_f == 5
 
     config = Configuration([0, 1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0, 0], ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
-    rj = rrc.ExternalAxes.from_configuration(config, ['b', 'c', 'd', 'e', 'f', 'g'])
+    rj = rrc.ExternalAxes.from_configuration_primitive(config, ['b', 'c', 'd', 'e', 'f', 'g'])
     assert rj.eax_a == 1
     assert rj.eax_f == 6

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,6 @@
 import math
 
+from compas.robots import Configuration
 import compas_rrc as rrc
 
 
@@ -40,6 +41,16 @@ def test_robot_joints():
     assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
     assert len(c.joint_names) == 0
 
+    config = Configuration([0, 1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0])
+    rj = rrc.RobotJoints.from_configuration(config)
+    assert rj.rax_1 == 0
+    assert rj.rax_6 == 5
+
+    config = Configuration([0, 1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0, 0], ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    rj = rrc.RobotJoints.from_configuration(config, ['b', 'c', 'd', 'e', 'f', 'g'])
+    assert rj.rax_1 == 1
+    assert rj.rax_6 == 6
+
 
 def test_external_axes():
     ea = rrc.ExternalAxes()
@@ -51,11 +62,11 @@ def test_external_axes():
     ea = rrc.ExternalAxes(30, 10, 0)
     assert list(ea) == [30, 10, 0]
 
-    # ea = rrc.ExternalAxes([30, 10, 0])
-    # assert list(ea) == [30, 10, 0]
-    #
-    # ea = rrc.ExternalAxes(iter([30, 10, 0]))
-    # assert list(ea) == [30, 10, 0]
+    ea = rrc.ExternalAxes([30, 10, 0])
+    assert list(ea) == [30, 10, 0]
+
+    ea = rrc.ExternalAxes(iter([30, 10, 0]))
+    assert list(ea) == [30, 10, 0]
 
     j = rrc.ExternalAxes(30, 45, 0)
     c = j.to_configuration([0, 1, 2], ['j1', 'j2', 'j3'])
@@ -66,3 +77,13 @@ def test_external_axes():
     c = j.to_configuration([0, 1, 2])
     assert c.joint_values == [math.pi/6, -math.pi/4, 0.1]
     assert len(c.joint_names) == 0
+
+    config = Configuration([0, 1, 2, 3, 4, 5], [0, 0, 0, 0, 0, 0])
+    rj = rrc.ExternalAxes.from_configuration(config)
+    assert rj.eax_a == 0
+    assert rj.eax_f == 5
+
+    config = Configuration([0, 1, 2, 3, 4, 5, 6], [0, 0, 0, 0, 0, 0, 0], ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    rj = rrc.ExternalAxes.from_configuration(config, ['b', 'c', 'd', 'e', 'f', 'g'])
+    assert rj.eax_a == 1
+    assert rj.eax_f == 6


### PR DESCRIPTION
I'm switching over from the fork to making a PR directly to avoid failing tests.  Pardon me for interrupting the flow of conversation. 

Regarding the second point 
>from_configuration() as a static method. Also poses some questions, since it should return two objects (RobotJoints and ExternalAxes), so it doesn't fit exactly on either, but if I had to choose, I guess RobotJoints being the "primary" one is the better fit.

It made sense to me to add this method to both classes and to allow the user to specify either the `group` or the `joint_names` to be included in the `compas_rrc` object, rather than trying to figure out which of the joints are external and which are internal programmatically.

Regarding python's lack of overloading, are the names ok?

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
